### PR TITLE
Check access token during UI login verification

### DIFF
--- a/lr-inaturalist-publish.lrdevplugin/Login.lua
+++ b/lr-inaturalist-publish.lrdevplugin/Login.lua
@@ -12,7 +12,9 @@ local sha2 = require("sha2")
 local Login = {}
 
 function Login.verifyLogin(propertyTable)
-	if propertyTable.login and #propertyTable.login > 0 then
+	logger:trace("Login.verifyLogin()")
+
+	if propertyTable.login and #propertyTable.login > 0 and LrPasswords.retrieve(propertyTable.login) then
 		propertyTable.accountStatus = "Logged in as " .. propertyTable.login
 		propertyTable.loginButtonEnabled = false
 		propertyTable.LR_cantExportBecause = nil
@@ -70,6 +72,8 @@ function Login.handleAuthRedirect(url)
 			)
 			return
 		end
+		-- Ensure that login is changed so that verifyLogin runs (in case of re-login)
+		propertyTable.login = nil
 		LrTasks.startAsyncTask(function()
 			local accessToken = Login.getToken(params["code"], propertyTable.pkceChallenge)
 			propertyTable.pkceChallenge = nil

--- a/lr-inaturalist-publish.lrdevplugin/Login.lua
+++ b/lr-inaturalist-publish.lrdevplugin/Login.lua
@@ -38,15 +38,6 @@ end
 function Login.login(propertyTable)
 	logger:trace("Login.login()")
 
-	-- The same button acts as the Log out button. If already logged in, then
-	-- log out instead.
-	if propertyTable.login and #propertyTable.login > 0 then
-		logger:debugf("Logging out: %s", propertyTable.login)
-		propertyTable.loggedOut = propertyTable.login
-		propertyTable.login = ""
-		return
-	end
-
 	local baseUrl = "https://www.inaturalist.org/oauth/authorize"
 	local challenge = generateSecret()
 	local code_challenge = base64urlencode(sha2.hex_to_bin(sha2.sha256(challenge)))


### PR DESCRIPTION
When opening a catalog on a different computer, the access token stored
with LrPasswords will not be available. Without this change, there is no
way to get an access token from this state -- the "Log in" button is
greyed out, as there is a username stored in the plugin propertyTable of
the catalog.

This change allows the user to log in again when moving their catalog to
a new computer.